### PR TITLE
Update script to handle any version of macOS with profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 MDM Status module
 ================
-This module requires macOS 10.13.4 or higher due to a change introduced in 10.13.4 to provide status.
-
 The "MDM Enrolled" widget values are as follows:
   No = Not enrolled in MDM
   DEP = DEP enrolled MDM
@@ -13,4 +11,3 @@ The following information is stored in the mdm_status table:
 	- "Yes" or "No"
 * MDM Enrollment Status 10.13.4+
 	- "No", "Yes" installed but not approved, "Yes (User Approved)"
-	

--- a/scripts/mdm_status.py
+++ b/scripts/mdm_status.py
@@ -10,7 +10,7 @@ import plistlib
 import sys
 import platform
 
-def get_mdm_status():
+def get_mdm_status_modern():
     '''Uses profiles command to get MDM status for this machine.
     Requires macOS 10.13.4 due to MDM status output changes.'''
     cmd = ['/usr/bin/profiles', 'status', '-type', 'enrollment']
@@ -18,7 +18,7 @@ def get_mdm_status():
                             stdin=subprocess.PIPE,
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     (output, unused_error) = proc.communicate()
-    
+
     enrolled_via_dep = ''
     mdm_enrollment = ''
     values = output.split('\n')
@@ -29,21 +29,48 @@ def get_mdm_status():
                 enrolled_via_dep = "Yes"
             else:
                 enrolled_via_dep = "No"
-                
+
         if "MDM enrollment:" in value:
             mdm_enrollment = value.split(':')[1].lstrip()
-            
+
     result = {}
     result.update({'mdm_enrolled_via_dep': enrolled_via_dep})
     result.update({'mdm_enrolled': mdm_enrollment})
     return result
 
-def getMinorOsVersion():
+def get_mdm_status_legacy():
+    """Uses profiles command on older versions of macOS to check if a machine
+    is enrolled in MDM."""
+    cmd = ['/usr/bin/profiles', '-C', '-o', 'stdout-xml']
+    run = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    output, err = run.communicate()
+
+    try:
+        plist = plistlib.readPlistFromString(output)
+    except: # pylint: disable=bare-except
+        plist = {'_computerlevel': []}
+
+    try:
+        for possible_plist in plist['_computerlevel']:
+            for item_content in possible_plist['ProfileItems']:
+                try:
+                    profile_type = item_content['PayloadType']
+                except KeyError:
+                    profile_type = ''
+                if profile_type == 'com.apple.mdm':
+                    return {'mdm_enrolled': "Yes"}
+    except KeyError:
+        return {'mdm_enrolled': "No"}
+
+    return {'mdm_enrolled': "No"}
+
+
+def get_minor_os_version():
     """Returns the minor OS version."""
     os_version_tuple = platform.mac_ver()[0].split('.')
     return int(os_version_tuple[1])
 
-def getPatchOsVersion():
+def get_patch_os_version():
     """Returns the minor OS version."""
     os_version_tuple = platform.mac_ver()[0].split('.')
     return int(os_version_tuple[2])
@@ -60,15 +87,15 @@ def main():
         if sys.argv[1] == 'manualcheck':
             print 'Manual check: skipping'
             exit(0)
-    
-    if getMinorOsVersion() <= 13 and getPatchOsVersion() < 4:
-        #result = {'mdm_enrolled': 'Output Not Supported', 'enrolled_via_dep': 'Output Not Supported'}
-        exit(0) # OS not supported, don't report anything
+    result = dict()
+    if get_minor_os_version() >= 13:
+        if get_patch_os_version >= 4:
+            result = get_mdm_status_modern()
+        else:
+            result = get_mdm_status_legacy()
     else:
-        # Get results
-        result = dict()
-        result = get_mdm_status()
-    
+        result = get_mdm_status_legacy()
+
     # Write mdm status results to cache
     output_plist = os.path.join(cachedir, 'mdm_status.plist')
     plistlib.writePlist(result, output_plist)

--- a/scripts/mdm_status.py
+++ b/scripts/mdm_status.py
@@ -45,6 +45,7 @@ def get_mdm_status_legacy():
     run = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     output, err = run.communicate()
 
+    result = {}
     try:
         plist = plistlib.readPlistFromString(output)
     except: # pylint: disable=bare-except
@@ -58,11 +59,16 @@ def get_mdm_status_legacy():
                 except KeyError:
                     profile_type = ''
                 if profile_type == 'com.apple.mdm':
-                    return {'mdm_enrolled': "Yes"}
+                    result.update({'mdm_enrolled': "Yes"})
+                    return result
     except KeyError:
-        return {'mdm_enrolled': "No"}
+        result.update({'mdm_enrolled': "No"})
+        result.update({'mdm_enrolled_via_dep': "No"})
+        return result
 
-    return {'mdm_enrolled': "No"}
+    result.update({'mdm_enrolled': "No"})
+    result.update({'mdm_enrolled_via_dep': "No"})
+    return result
 
 
 def get_minor_os_version():


### PR DESCRIPTION
This version of the script steals checks from @erikng's umad project, thanks @poundbangbash for posting it! The improved script will report back on MDM status for any supported version of macOS that has the profiles command, and does the extended checks for DEP / UAMDM on 10.13.4 and up.