### PR TITLE
Listing improvements

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -6,6 +6,7 @@
 	"not_uamdm": "Not User Approved",
 	"non_uamdm": "Non-UAMDM",
     "mdm_enrolled_via_dep": "Enrolled via DEP",
+    "mdm_not_enrolled_via_dep": "Not Enrolled via DEP",
     "mdm_enrollment": "MDM Enrollment",
  	"mdm_user_approved": "User Approved MDM Status",
  	"no": "No",

--- a/views/mdm_status_listing.php
+++ b/views/mdm_status_listing.php
@@ -19,9 +19,9 @@ new Mdm_status_model;
 		      <tr>
 		        <th data-i18n="listing.computername" data-colname='machine.computer_name'></th>
 		        <th data-i18n="serial" data-colname='reportdata.serial_number'></th>
-		        <th data-i18n="username" data-colname='reportdata.long_username'></th>
+                <th data-i18n="username" data-colname='reportdata.long_username'></th>
+                <th data-i18n="mdm_status.mdm_enrollment" data-colname='mdm_status.mdm_enrolled'></th>
 		        <th data-i18n="mdm_status.mdm_enrolled_via_dep" data-colname='mdm_status.mdm_enrolled_via_dep'></th>
-		        <th data-i18n="mdm_status.mdm_enrollment" data-colname='mdm_status.mdm_enrolled'></th>
 		      </tr>
 		    </thead>
 		    <tbody>
@@ -88,7 +88,7 @@ new Mdm_status_model;
 	        	var link = mr.getClientDetailLink(name, sn);
 	        	$('td:eq(0)', nRow).html(link);
 
-            var dep_enrolled = $('td:eq(3)', nRow).html();
+            var dep_enrolled = $('td:eq(4)', nRow).html();
             $('td:eq(3)', nRow).html(function(){
                 if( dep_enrolled == 'Yes'){
                     return '<span class="label label-success">'+i18n.t('mdm_status.enrolled')+'</span>';
@@ -96,7 +96,7 @@ new Mdm_status_model;
                 return '<span class="label label-danger">'+i18n.t('mdm_status.not_enrolled')+'</span>';
             });
 
-            var mdm_enrolled = $('td:eq(4)', nRow).html();
+            var mdm_enrolled = $('td:eq(3)', nRow).html();
             $('td:eq(4)', nRow).html(function(){
                 if( mdm_enrolled == 'Yes'){
                     return '<span class="label label-warning">'+i18n.t('mdm_status.not_uamdm')+'</span>';

--- a/views/mdm_status_listing.php
+++ b/views/mdm_status_listing.php
@@ -91,9 +91,9 @@ new Mdm_status_model;
             var dep_enrolled = $('td:eq(4)', nRow).html();
             $('td:eq(3)', nRow).html(function(){
                 if( dep_enrolled == 'Yes'){
-                    return '<span class="label label-success">'+i18n.t('mdm_status.enrolled')+'</span>';
+                    return '<span class="label label-success">'+i18n.t('mdm_status.mdm_enrolled_via_dep')+'</span>';
                 }
-                return '<span class="label label-danger">'+i18n.t('mdm_status.not_enrolled')+'</span>';
+                return '<span class="label label-danger">'+i18n.t('mdm_status.mdm_not_enrolled_via_dep')+'</span>';
             });
 
             var mdm_enrolled = $('td:eq(3)', nRow).html();


### PR DESCRIPTION
* reverse the order of the two columns in the listing to have the enrollment status first, then DEP status
* re-word the DEP translation elements to more clearly reflect that they are only talking about DEP and not overall status