### PR TITLE
show pre-10.13.4 MDM enrollments as user-approved

### DIFF
--- a/scripts/mdm_status.py
+++ b/scripts/mdm_status.py
@@ -59,7 +59,7 @@ def get_mdm_status_legacy():
                 except KeyError:
                     profile_type = ''
                 if profile_type == 'com.apple.mdm':
-                    result.update({'mdm_enrolled': "Yes"})
+                    result.update({'mdm_enrolled': "Yes (User Approved)"})
                     return result
     except KeyError:
         result.update({'mdm_enrolled': "No"})


### PR DESCRIPTION
Does what it says on the tin. Anything under 10.13.4 that uses the _legacy function in the script will show as user-approved in reporting.