### PR TITLE
Adjust sql comparison for uamdm status

### DIFF
--- a/mdm_status_model.php
+++ b/mdm_status_model.php
@@ -70,7 +70,7 @@ class Mdm_status_model extends \Model
     {
         $sql = "SELECT COUNT(CASE WHEN mdm_enrolled = 'NO' THEN 1 END) AS mdm_no,
 			COUNT(CASE WHEN mdm_enrolled = 'Yes' THEN 1 END) AS non_uamdm, 
-			COUNT(CASE WHEN mdm_enrolled = 'Yes (User Approved)' AND mdm_enrolled_via_dep = 'No' THEN 1 END) AS uamdm,
+			COUNT(CASE WHEN mdm_enrolled = 'Yes (User Approved)' AND mdm_enrolled_via_dep <> 'Yes' THEN 1 END) AS uamdm,
 			COUNT(CASE WHEN mdm_enrolled = 'Yes (User Approved)' AND mdm_enrolled_via_dep = 'Yes' THEN 1 END) AS dep_enrolled			
 			FROM mdm_status
 			LEFT JOIN reportdata USING (serial_number)


### PR DESCRIPTION
Since < 10.13.4 machines aren't returning a DEP status I changed the comparison for evaluating if a machine is UAMDM so the report is correct.