### PR TITLE
Hostname only server url

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,5 @@ The following information is stored in the mdm_status table:
 	- "Yes" or "No"
 * MDM Enrollment Status 10.13.4+
 	- "No", "Yes" installed but not approved, "Yes (User Approved)"
+* Server URL
+    - Captures the base URL of the MDM enrollment

--- a/scripts/mdm_status.py
+++ b/scripts/mdm_status.py
@@ -9,6 +9,7 @@ import os
 import plistlib
 import sys
 import platform
+import re
 
 def get_mdm_server_url():
     """Uses profiles command to detect the MDM server hostname."""
@@ -31,7 +32,8 @@ def get_mdm_server_url():
                     profile_type = ''
                 if profile_type == 'com.apple.mdm':
                     try:
-                        mdm_server_url = item_content['PayloadContent']['ServerURL']
+                        mdm_full_server_url = item_content['PayloadContent']['ServerURL']
+                        mdm_server_url = re.match('http.?:\/\/[\S]+(?=\/)', mdm_full_server_url).group()
                     except KeyError:
                         mdm_server_url = ''
     except KeyError:


### PR DESCRIPTION
Some MDM vendors have extremely long URLs.  This change captures just the base URL instead of full URL.