### PR TITLE
Fix regex pattern for mdm_server_url extraction

### DIFF
--- a/scripts/mdm_status.py
+++ b/scripts/mdm_status.py
@@ -36,7 +36,7 @@ def get_mdm_server_url():
                 if profile_type == 'com.apple.mdm':
                     try:
                         mdm_full_server_url = item_content['PayloadContent']['ServerURL']
-                        mdm_server_url = re.match('http.?:\/\/[\S]+(?=\/)', mdm_full_server_url).group()
+                        mdm_server_url = re.match(r'http.?://\S+(?=/)', mdm_full_server_url).group()
                     except KeyError:
                         mdm_server_url = ''
     except KeyError:


### PR DESCRIPTION
Make it compatible with Python 3.11 and 3.12. Also maintains compatibility with Python 3.10